### PR TITLE
Add reference packages for Microsoft.Bcl.TimeProvider, Microsoft.Extensions.Logging.Abstractions, and System.Diagnostics.DiagnosticSource

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -73,6 +73,11 @@
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Security.Cryptography.Pkcs.8.0.1.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Security.Cryptography.Xml.8.0.3.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Logging.Abstractions.2.1.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Logging.Abstractions.6.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Diagnostics.DiagnosticSource.6.0.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Bcl.TimeProvider.8.0.1.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/Microsoft.Bcl.TimeProvider.8.0.1.csproj
+++ b/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/Microsoft.Bcl.TimeProvider.8.0.1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Bcl.TimeProvider</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/lib/net8.0/Microsoft.Bcl.TimeProvider.cs
+++ b/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/lib/net8.0/Microsoft.Bcl.TimeProvider.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.TimeProvider")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for system time abstraction primitives for .NET Framework and .NET Standard.\r\n\r\nCommonly Used Types:\r\nSystem.TimeProvider\r\nSystem.ITimer")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.123.58001")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.1+bf5e279d9239bfef5bb1b8d6212f1b971c434606")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.TimeProvider")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Threading.ITimer))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.TimeProvider))]
+namespace System.Threading.Tasks
+{
+    public static partial class TimeProviderTaskExtensions
+    {
+        public static CancellationTokenSource CreateCancellationTokenSource(this TimeProvider timeProvider, TimeSpan delay) { throw null; }
+
+        public static Task Delay(this TimeProvider timeProvider, TimeSpan delay, CancellationToken cancellationToken = default) { throw null; }
+
+        public static Task WaitAsync(this Task task, TimeSpan timeout, TimeProvider timeProvider, CancellationToken cancellationToken = default) { throw null; }
+
+        public static Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout, TimeProvider timeProvider, CancellationToken cancellationToken = default) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/lib/netstandard2.0/Microsoft.Bcl.TimeProvider.cs
+++ b/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/lib/netstandard2.0/Microsoft.Bcl.TimeProvider.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.TimeProvider")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for system time abstraction primitives for .NET Framework and .NET Standard.\r\n\r\nCommonly Used Types:\r\nSystem.TimeProvider\r\nSystem.ITimer")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.123.58001")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.1+bf5e279d9239bfef5bb1b8d6212f1b971c434606")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.TimeProvider")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System
+{
+    public abstract partial class TimeProvider
+    {
+        public virtual TimeZoneInfo LocalTimeZone { get { throw null; } }
+
+        public static TimeProvider System { get { throw null; } }
+
+        public virtual long TimestampFrequency { get { throw null; } }
+
+        public virtual Threading.ITimer CreateTimer(Threading.TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) { throw null; }
+
+        public TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) { throw null; }
+
+        public TimeSpan GetElapsedTime(long startingTimestamp) { throw null; }
+
+        public DateTimeOffset GetLocalNow() { throw null; }
+
+        public virtual long GetTimestamp() { throw null; }
+
+        public virtual DateTimeOffset GetUtcNow() { throw null; }
+    }
+}
+
+namespace System.Threading
+{
+    public partial interface ITimer : IDisposable, IAsyncDisposable
+    {
+        bool Change(TimeSpan dueTime, TimeSpan period);
+    }
+}
+
+namespace System.Threading.Tasks
+{
+    public static partial class TimeProviderTaskExtensions
+    {
+        public static CancellationTokenSource CreateCancellationTokenSource(this TimeProvider timeProvider, TimeSpan delay) { throw null; }
+
+        public static Task Delay(this TimeProvider timeProvider, TimeSpan delay, CancellationToken cancellationToken = default) { throw null; }
+
+        public static Task WaitAsync(this Task task, TimeSpan timeout, TimeProvider timeProvider, CancellationToken cancellationToken = default) { throw null; }
+
+        public static Task<TResult> WaitAsync<TResult>(this Task<TResult> task, TimeSpan timeout, TimeProvider timeProvider, CancellationToken cancellationToken = default) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/microsoft.bcl.timeprovider.nuspec
+++ b/src/referencePackages/src/microsoft.bcl.timeprovider/8.0.1/microsoft.bcl.timeprovider.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Bcl.TimeProvider</id>
+    <version>8.0.1</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides support for system time abstraction primitives for .NET Framework and .NET Standard.
+
+Commonly Used Types:
+System.TimeProvider
+System.ITimer</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="bf5e279d9239bfef5bb1b8d6212f1b971c434606" />
+    <dependencies>
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/Microsoft.Extensions.Logging.Abstractions.2.1.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/Microsoft.Extensions.Logging.Abstractions.2.1.0.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.cs
@@ -1,0 +1,305 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Extensions.Logging.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("CommitHash", "6dffd8b4f6b6e2204224ae586cbea19375a7d206")]
+[assembly: System.Reflection.AssemblyMetadata("BuildNumber", "30799")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation.")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Logging abstractions for Microsoft.Extensions.Logging.\nCommonly used types:\nMicrosoft.Extensions.Logging.ILogger\nMicrosoft.Extensions.Logging.ILoggerFactory\nMicrosoft.Extensions.Logging.ILogger<TCategoryName>\nMicrosoft.Extensions.Logging.LogLevel\nMicrosoft.Extensions.Logging.Logger<T>\nMicrosoft.Extensions.Logging.LoggerMessage\nMicrosoft.Extensions.Logging.Abstractions.NullLogger")]
+[assembly: System.Reflection.AssemblyFileVersion("2.1.0.18136")]
+[assembly: System.Reflection.AssemblyInformationalVersion("2.1.0-rtm-30799")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft .NET Extensions")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Extensions.Logging.Abstractions")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.1.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Extensions.Logging
+{
+    public partial struct EventId
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public EventId(int id, string name = null) { }
+
+        public int Id { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public bool Equals(EventId other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(EventId left, EventId right) { throw null; }
+
+        public static implicit operator EventId(int i) { throw null; }
+
+        public static bool operator !=(EventId left, EventId right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial interface IExternalScopeProvider
+    {
+        void ForEachScope<TState>(System.Action<object, TState> callback, TState state);
+        System.IDisposable Push(object state);
+    }
+
+    public partial interface ILogger
+    {
+        System.IDisposable BeginScope<TState>(TState state);
+        bool IsEnabled(LogLevel logLevel);
+        void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter);
+    }
+
+    public partial interface ILoggerFactory : System.IDisposable
+    {
+        void AddProvider(ILoggerProvider provider);
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILoggerProvider : System.IDisposable
+    {
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILogger<out TCategoryName> : ILogger
+    {
+    }
+
+    public partial interface ISupportExternalScope
+    {
+        void SetScopeProvider(IExternalScopeProvider scopeProvider);
+    }
+
+    public static partial class LoggerExtensions
+    {
+        public static System.IDisposable BeginScope(this ILogger logger, string messageFormat, params object[] args) { throw null; }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string message, params object[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, System.Exception exception, string message, params object[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, string message, params object[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogCritical(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogCritical(this ILogger logger, string message, params object[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogDebug(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogDebug(this ILogger logger, string message, params object[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogError(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogError(this ILogger logger, string message, params object[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogInformation(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogInformation(this ILogger logger, string message, params object[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogTrace(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogTrace(this ILogger logger, string message, params object[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, string message, params object[] args) { }
+
+        public static void LogWarning(this ILogger logger, System.Exception exception, string message, params object[] args) { }
+
+        public static void LogWarning(this ILogger logger, string message, params object[] args) { }
+    }
+
+    public partial class LoggerExternalScopeProvider : IExternalScopeProvider
+    {
+        public void ForEachScope<TState>(System.Action<object, TState> callback, TState state) { }
+
+        public System.IDisposable Push(object state) { throw null; }
+    }
+
+    public static partial class LoggerFactoryExtensions
+    {
+        public static ILogger CreateLogger(this ILoggerFactory factory, System.Type type) { throw null; }
+
+        public static ILogger<T> CreateLogger<T>(this ILoggerFactory factory) { throw null; }
+    }
+
+    public static partial class LoggerMessage
+    {
+        public static System.Action<ILogger, System.Exception> Define(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, System.Exception> Define<T1>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, System.Exception> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, System.Exception> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, System.Exception> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, System.Exception> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, T6, System.Exception> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Func<ILogger, System.IDisposable> DefineScope(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, System.IDisposable> DefineScope<T1>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, System.IDisposable> DefineScope<T1, T2>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, System.IDisposable> DefineScope<T1, T2, T3>(string formatString) { throw null; }
+    }
+
+    public partial class Logger<T> : ILogger<T>, ILogger
+    {
+        public Logger(ILoggerFactory factory) { }
+
+        System.IDisposable ILogger.BeginScope<TState>(TState state) { throw null; }
+
+        bool ILogger.IsEnabled(LogLevel logLevel) { throw null; }
+
+        void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+    }
+
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4,
+        Critical = 5,
+        None = 6
+    }
+}
+
+namespace Microsoft.Extensions.Logging.Abstractions
+{
+    public partial class NullLogger : ILogger
+    {
+        internal NullLogger() { }
+
+        public static NullLogger Instance { get { throw null; } }
+
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+    }
+
+    public partial class NullLoggerFactory : ILoggerFactory, System.IDisposable
+    {
+        public static readonly NullLoggerFactory Instance;
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public ILogger CreateLogger(string name) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLoggerProvider : ILoggerProvider, System.IDisposable
+    {
+        internal NullLoggerProvider() { }
+
+        public static NullLoggerProvider Instance { get { throw null; } }
+
+        public ILogger CreateLogger(string categoryName) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLogger<T> : ILogger<T>, ILogger
+    {
+        public static readonly NullLogger<T> Instance;
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+    }
+}
+
+namespace Microsoft.Extensions.Logging.Abstractions.Internal
+{
+    public partial class NullScope : System.IDisposable
+    {
+        internal NullScope() { }
+
+        public static NullScope Instance { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public partial class TypeNameHelper
+    {
+        public static string GetTypeDisplayName(System.Type type) { throw null; }
+    }
+}
+
+namespace Microsoft.Extensions.Logging.Internal
+{
+    public partial class FormattedLogValues : System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object>>
+    {
+        public FormattedLogValues(string format, params object[] values) { }
+
+        public int Count { get { throw null; } }
+
+        public System.Collections.Generic.KeyValuePair<string, object> this[int index] { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LogValuesFormatter
+    {
+        public LogValuesFormatter(string format) { }
+
+        public string OriginalFormat { get { throw null; } }
+
+        public System.Collections.Generic.List<string> ValueNames { get { throw null; } }
+
+        public string Format(object[] values) { throw null; }
+
+        public System.Collections.Generic.KeyValuePair<string, object> GetValue(object[] values, int index) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> GetValues(object[] values) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/microsoft.extensions.logging.abstractions.nuspec
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.0/microsoft.extensions.logging.abstractions.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Extensions.Logging.Abstractions</id>
+    <version>2.1.0</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</licenseUrl>
+    <projectUrl>https://asp.net/</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Logging abstractions for Microsoft.Extensions.Logging.
+Commonly used types:
+Microsoft.Extensions.Logging.ILogger
+Microsoft.Extensions.Logging.ILoggerFactory
+Microsoft.Extensions.Logging.ILogger&lt;TCategoryName&gt;
+Microsoft.Extensions.Logging.LogLevel
+Microsoft.Extensions.Logging.Logger&lt;T&gt;
+Microsoft.Extensions.Logging.LoggerMessage
+Microsoft.Extensions.Logging.Abstractions.NullLogger</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>logging</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/aspnet/Logging" commit="6dffd8b4f6b6e2204224ae586cbea19375a7d206" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/Microsoft.Extensions.Logging.Abstractions.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/Microsoft.Extensions.Logging.Abstractions.6.0.0.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/lib/net6.0/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/lib/net6.0/Microsoft.Extensions.Logging.Abstractions.cs
@@ -1,0 +1,323 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Extensions.Logging.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = "")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Extensions.Logging.Abstractions")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Logging abstractions for Microsoft.Extensions.Logging.\r\n\r\nCommonly Used Types:\r\nMicrosoft.Extensions.Logging.ILogger\r\nMicrosoft.Extensions.Logging.ILoggerFactory\r\nMicrosoft.Extensions.Logging.ILogger<TCategoryName>\r\nMicrosoft.Extensions.Logging.LogLevel\r\nMicrosoft.Extensions.Logging.Logger<T>\r\nMicrosoft.Extensions.Logging.LoggerMessage\r\nMicrosoft.Extensions.Logging.Abstractions.NullLogger")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.21.52210")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.0+4822e3c3aa77eb82b2fb33c9321f923cf11ddde6")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Extensions.Logging.Abstractions")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Extensions.Logging
+{
+    public readonly partial struct EventId
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public EventId(int id, string? name = null) { }
+
+        public int Id { get { throw null; } }
+
+        public string? Name { get { throw null; } }
+
+        public readonly bool Equals(EventId other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(EventId left, EventId right) { throw null; }
+
+        public static implicit operator EventId(int i) { throw null; }
+
+        public static bool operator !=(EventId left, EventId right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial interface IExternalScopeProvider
+    {
+        void ForEachScope<TState>(System.Action<object?, TState> callback, TState state);
+        System.IDisposable Push(object? state);
+    }
+
+    public partial interface ILogger
+    {
+        System.IDisposable BeginScope<TState>(TState state);
+        bool IsEnabled(LogLevel logLevel);
+        void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter);
+    }
+
+    public partial interface ILoggerFactory : System.IDisposable
+    {
+        void AddProvider(ILoggerProvider provider);
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILoggerProvider : System.IDisposable
+    {
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILogger<out TCategoryName> : ILogger
+    {
+    }
+
+    public partial interface ISupportExternalScope
+    {
+        void SetScopeProvider(IExternalScopeProvider scopeProvider);
+    }
+
+    public partial class LogDefineOptions
+    {
+        public bool SkipEnabledCheck { get { throw null; } set { } }
+    }
+
+    public static partial class LoggerExtensions
+    {
+        public static System.IDisposable BeginScope(this ILogger logger, string messageFormat, params object?[] args) { throw null; }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, string? message, params object?[] args) { }
+    }
+
+    public partial class LoggerExternalScopeProvider : IExternalScopeProvider
+    {
+        public void ForEachScope<TState>(System.Action<object?, TState> callback, TState state) { }
+
+        public System.IDisposable Push(object? state) { throw null; }
+    }
+
+    public static partial class LoggerFactoryExtensions
+    {
+        public static ILogger CreateLogger(this ILoggerFactory factory, System.Type type) { throw null; }
+
+        public static ILogger<T> CreateLogger<T>(this ILoggerFactory factory) { throw null; }
+    }
+
+    public static partial class LoggerMessage
+    {
+        public static System.Action<ILogger, System.Exception?> Define(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, System.Exception?> Define(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, System.Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, System.Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, System.Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, System.Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, System.Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, System.Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, System.Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, System.Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, System.Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, System.Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, T6, System.Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, T6, System.Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Func<ILogger, System.IDisposable> DefineScope(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, System.IDisposable> DefineScope<T1>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, System.IDisposable> DefineScope<T1, T2>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, System.IDisposable> DefineScope<T1, T2, T3>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, System.IDisposable> DefineScope<T1, T2, T3, T4>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, T5, System.IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Method)]
+    public sealed partial class LoggerMessageAttribute : System.Attribute
+    {
+        public LoggerMessageAttribute() { }
+
+        public LoggerMessageAttribute(int eventId, LogLevel level, string message) { }
+
+        public int EventId { get { throw null; } set { } }
+
+        public string? EventName { get { throw null; } set { } }
+
+        public LogLevel Level { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public bool SkipEnabledCheck { get { throw null; } set { } }
+    }
+
+    public partial class Logger<T> : ILogger<T>, ILogger
+    {
+        public Logger(ILoggerFactory factory) { }
+
+        System.IDisposable ILogger.BeginScope<TState>(TState state) { throw null; }
+
+        bool ILogger.IsEnabled(LogLevel logLevel) { throw null; }
+
+        void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+    }
+
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4,
+        Critical = 5,
+        None = 6
+    }
+}
+
+namespace Microsoft.Extensions.Logging.Abstractions
+{
+    public readonly partial struct LogEntry<TState>
+    {
+        private readonly TState _State_k__BackingField;
+        private readonly System.Func<TState, System.Exception, string> _Formatter_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public LogEntry(LogLevel logLevel, string category, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+
+        public string Category { get { throw null; } }
+
+        public EventId EventId { get { throw null; } }
+
+        public System.Exception? Exception { get { throw null; } }
+
+        public System.Func<TState, System.Exception?, string>? Formatter { get { throw null; } }
+
+        public LogLevel LogLevel { get { throw null; } }
+
+        public TState State { get { throw null; } }
+    }
+
+    public partial class NullLogger : ILogger
+    {
+        internal NullLogger() { }
+
+        public static NullLogger Instance { get { throw null; } }
+
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+    }
+
+    public partial class NullLoggerFactory : ILoggerFactory, System.IDisposable
+    {
+        public static readonly NullLoggerFactory Instance;
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public ILogger CreateLogger(string name) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLoggerProvider : ILoggerProvider, System.IDisposable
+    {
+        internal NullLoggerProvider() { }
+
+        public static NullLoggerProvider Instance { get { throw null; } }
+
+        public ILogger CreateLogger(string categoryName) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLogger<T> : ILogger<T>, ILogger
+    {
+        public static readonly NullLogger<T> Instance;
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+    }
+}

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.cs
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.cs
@@ -1,0 +1,323 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Extensions.Logging.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Extensions.Logging.Abstractions")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Logging abstractions for Microsoft.Extensions.Logging.\r\n\r\nCommonly Used Types:\r\nMicrosoft.Extensions.Logging.ILogger\r\nMicrosoft.Extensions.Logging.ILoggerFactory\r\nMicrosoft.Extensions.Logging.ILogger<TCategoryName>\r\nMicrosoft.Extensions.Logging.LogLevel\r\nMicrosoft.Extensions.Logging.Logger<T>\r\nMicrosoft.Extensions.Logging.LoggerMessage\r\nMicrosoft.Extensions.Logging.Abstractions.NullLogger")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.21.52210")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.0+4822e3c3aa77eb82b2fb33c9321f923cf11ddde6")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Extensions.Logging.Abstractions")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Extensions.Logging
+{
+    public readonly partial struct EventId
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public EventId(int id, string? name = null) { }
+
+        public int Id { get { throw null; } }
+
+        public string? Name { get { throw null; } }
+
+        public readonly bool Equals(EventId other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(EventId left, EventId right) { throw null; }
+
+        public static implicit operator EventId(int i) { throw null; }
+
+        public static bool operator !=(EventId left, EventId right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial interface IExternalScopeProvider
+    {
+        void ForEachScope<TState>(System.Action<object?, TState> callback, TState state);
+        System.IDisposable Push(object? state);
+    }
+
+    public partial interface ILogger
+    {
+        System.IDisposable BeginScope<TState>(TState state);
+        bool IsEnabled(LogLevel logLevel);
+        void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter);
+    }
+
+    public partial interface ILoggerFactory : System.IDisposable
+    {
+        void AddProvider(ILoggerProvider provider);
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILoggerProvider : System.IDisposable
+    {
+        ILogger CreateLogger(string categoryName);
+    }
+
+    public partial interface ILogger<out TCategoryName> : ILogger
+    {
+    }
+
+    public partial interface ISupportExternalScope
+    {
+        void SetScopeProvider(IExternalScopeProvider scopeProvider);
+    }
+
+    public partial class LogDefineOptions
+    {
+        public bool SkipEnabledCheck { get { throw null; } set { } }
+    }
+
+    public static partial class LoggerExtensions
+    {
+        public static System.IDisposable BeginScope(this ILogger logger, string messageFormat, params object?[] args) { throw null; }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void Log(this ILogger logger, LogLevel logLevel, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogCritical(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogDebug(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogError(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogInformation(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogTrace(this ILogger logger, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, System.Exception? exception, string? message, params object?[] args) { }
+
+        public static void LogWarning(this ILogger logger, string? message, params object?[] args) { }
+    }
+
+    public partial class LoggerExternalScopeProvider : IExternalScopeProvider
+    {
+        public void ForEachScope<TState>(System.Action<object?, TState> callback, TState state) { }
+
+        public System.IDisposable Push(object? state) { throw null; }
+    }
+
+    public static partial class LoggerFactoryExtensions
+    {
+        public static ILogger CreateLogger(this ILoggerFactory factory, System.Type type) { throw null; }
+
+        public static ILogger<T> CreateLogger<T>(this ILoggerFactory factory) { throw null; }
+    }
+
+    public static partial class LoggerMessage
+    {
+        public static System.Action<ILogger, System.Exception?> Define(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, System.Exception?> Define(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, System.Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, System.Exception?> Define<T1>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, System.Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, System.Exception?> Define<T1, T2>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, System.Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, System.Exception?> Define<T1, T2, T3>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, System.Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, System.Exception?> Define<T1, T2, T3, T4>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, System.Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, System.Exception?> Define<T1, T2, T3, T4, T5>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, T6, System.Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString, LogDefineOptions? options) { throw null; }
+
+        public static System.Action<ILogger, T1, T2, T3, T4, T5, T6, System.Exception?> Define<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, EventId eventId, string formatString) { throw null; }
+
+        public static System.Func<ILogger, System.IDisposable> DefineScope(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, System.IDisposable> DefineScope<T1>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, System.IDisposable> DefineScope<T1, T2>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, System.IDisposable> DefineScope<T1, T2, T3>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, System.IDisposable> DefineScope<T1, T2, T3, T4>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, T5, System.IDisposable> DefineScope<T1, T2, T3, T4, T5>(string formatString) { throw null; }
+
+        public static System.Func<ILogger, T1, T2, T3, T4, T5, T6, System.IDisposable> DefineScope<T1, T2, T3, T4, T5, T6>(string formatString) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Method)]
+    public sealed partial class LoggerMessageAttribute : System.Attribute
+    {
+        public LoggerMessageAttribute() { }
+
+        public LoggerMessageAttribute(int eventId, LogLevel level, string message) { }
+
+        public int EventId { get { throw null; } set { } }
+
+        public string? EventName { get { throw null; } set { } }
+
+        public LogLevel Level { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public bool SkipEnabledCheck { get { throw null; } set { } }
+    }
+
+    public partial class Logger<T> : ILogger<T>, ILogger
+    {
+        public Logger(ILoggerFactory factory) { }
+
+        System.IDisposable ILogger.BeginScope<TState>(TState state) { throw null; }
+
+        bool ILogger.IsEnabled(LogLevel logLevel) { throw null; }
+
+        void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter) { }
+    }
+
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4,
+        Critical = 5,
+        None = 6
+    }
+}
+
+namespace Microsoft.Extensions.Logging.Abstractions
+{
+    public readonly partial struct LogEntry<TState>
+    {
+        private readonly TState _State_k__BackingField;
+        private readonly System.Func<TState, System.Exception, string> _Formatter_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public LogEntry(LogLevel logLevel, string category, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+
+        public string Category { get { throw null; } }
+
+        public EventId EventId { get { throw null; } }
+
+        public System.Exception? Exception { get { throw null; } }
+
+        public System.Func<TState, System.Exception?, string>? Formatter { get { throw null; } }
+
+        public LogLevel LogLevel { get { throw null; } }
+
+        public TState State { get { throw null; } }
+    }
+
+    public partial class NullLogger : ILogger
+    {
+        internal NullLogger() { }
+
+        public static NullLogger Instance { get { throw null; } }
+
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+    }
+
+    public partial class NullLoggerFactory : ILoggerFactory, System.IDisposable
+    {
+        public static readonly NullLoggerFactory Instance;
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public ILogger CreateLogger(string name) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLoggerProvider : ILoggerProvider, System.IDisposable
+    {
+        internal NullLoggerProvider() { }
+
+        public static NullLoggerProvider Instance { get { throw null; } }
+
+        public ILogger CreateLogger(string categoryName) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public partial class NullLogger<T> : ILogger<T>, ILogger
+    {
+        public static readonly NullLogger<T> Instance;
+        public System.IDisposable BeginScope<TState>(TState state) { throw null; }
+
+        public bool IsEnabled(LogLevel logLevel) { throw null; }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
+    }
+}

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/microsoft.extensions.logging.abstractions.nuspec
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.0/microsoft.extensions.logging.abstractions.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Extensions.Logging.Abstractions</id>
+    <version>6.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Logging abstractions for Microsoft.Extensions.Logging.
+
+Commonly Used Types:
+Microsoft.Extensions.Logging.ILogger
+Microsoft.Extensions.Logging.ILoggerFactory
+Microsoft.Extensions.Logging.ILogger&lt;TCategoryName&gt;
+Microsoft.Extensions.Logging.LogLevel
+Microsoft.Extensions.Logging.Logger&lt;T&gt;
+Microsoft.Extensions.Logging.LoggerMessage
+Microsoft.Extensions.Logging.Abstractions.NullLogger</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="4822e3c3aa77eb82b2fb33c9321f923cf11ddde6" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/System.Diagnostics.DiagnosticSource.6.0.2.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/System.Diagnostics.DiagnosticSource.6.0.2.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;net6.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Diagnostics.DiagnosticSource</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/net5.0/System.Diagnostics.DiagnosticSource.cs
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/net5.0/System.Diagnostics.DiagnosticSource.cs
@@ -1,0 +1,720 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = "")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)\r\n\r\nCommonly Used Types:\r\nSystem.Diagnostics.DiagnosticListener\r\nSystem.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.3624.51421")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.36+f1dd57165bfd91875761329ac3a8b17f6606ad18")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Diagnostics
+{
+    public partial class Activity : IDisposable
+    {
+        public Activity(string operationName) { }
+
+        public ActivityTraceFlags ActivityTraceFlags { get { throw null; } set { } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Baggage { get { throw null; } }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public static Activity? Current { get { throw null; } set { } }
+
+        public static ActivityIdFormat DefaultIdFormat { get { throw null; } set { } }
+
+        public string DisplayName { get { throw null; } set { } }
+
+        public TimeSpan Duration { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityEvent> Events { get { throw null; } }
+
+        public static bool ForceDefaultIdFormat { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } }
+
+        public ActivityIdFormat IdFormat { get { throw null; } }
+
+        public bool IsAllDataRequested { get { throw null; } set { } }
+
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink> Links { get { throw null; } }
+
+        public string OperationName { get { throw null; } }
+
+        public Activity? Parent { get { throw null; } }
+
+        public string? ParentId { get { throw null; } }
+
+        public ActivitySpanId ParentSpanId { get { throw null; } }
+
+        public bool Recorded { get { throw null; } }
+
+        public string? RootId { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public DateTime StartTimeUtc { get { throw null; } }
+
+        public ActivityStatusCode Status { get { throw null; } }
+
+        public string? StatusDescription { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> TagObjects { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public static Func<ActivityTraceId>? TraceIdGenerator { get { throw null; } set { } }
+
+        public string? TraceStateString { get { throw null; } set { } }
+
+        public Activity AddBaggage(string key, string? value) { throw null; }
+
+        public Activity AddEvent(ActivityEvent e) { throw null; }
+
+        public Activity AddTag(string key, object? value) { throw null; }
+
+        public Activity AddTag(string key, string? value) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public string? GetBaggageItem(string key) { throw null; }
+
+        public object? GetCustomProperty(string propertyName) { throw null; }
+
+        public object? GetTagItem(string key) { throw null; }
+
+        public Activity SetBaggage(string key, string? value) { throw null; }
+
+        public void SetCustomProperty(string propertyName, object? propertyValue) { }
+
+        public Activity SetEndTime(DateTime endTimeUtc) { throw null; }
+
+        public Activity SetIdFormat(ActivityIdFormat format) { throw null; }
+
+        public Activity SetParentId(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None) { throw null; }
+
+        public Activity SetParentId(string parentId) { throw null; }
+
+        public Activity SetStartTime(DateTime startTimeUtc) { throw null; }
+
+        public Activity SetStatus(ActivityStatusCode code, string? description = null) { throw null; }
+
+        public Activity SetTag(string key, object? value) { throw null; }
+
+        public Activity Start() { throw null; }
+
+        public void Stop() { }
+    }
+
+    public readonly partial struct ActivityContext : IEquatable<ActivityContext>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags, string? traceState = null, bool isRemote = false) { }
+
+        public bool IsRemote { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public ActivityTraceFlags TraceFlags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public string? TraceState { get { throw null; } }
+
+        public readonly bool Equals(ActivityContext value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static bool operator !=(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static ActivityContext Parse(string traceParent, string? traceState) { throw null; }
+
+        public static bool TryParse(string? traceParent, string? traceState, out ActivityContext context) { throw null; }
+    }
+
+    public readonly partial struct ActivityCreationOptions<T>
+    {
+        private readonly T _Parent_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink>? Links { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public T Parent { get { throw null; } }
+
+        public ActivityTagsCollection SamplingTags { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+    }
+
+    public readonly partial struct ActivityEvent
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityEvent(string name, DateTimeOffset timestamp = default, ActivityTagsCollection? tags = null) { }
+
+        public ActivityEvent(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+    }
+
+    public enum ActivityIdFormat
+    {
+        Unknown = 0,
+        Hierarchical = 1,
+        W3C = 2
+    }
+
+    public enum ActivityKind
+    {
+        Internal = 0,
+        Server = 1,
+        Client = 2,
+        Producer = 3,
+        Consumer = 4
+    }
+
+    public readonly partial struct ActivityLink : IEquatable<ActivityLink>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityLink(ActivityContext context, ActivityTagsCollection? tags = null) { }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public readonly bool Equals(ActivityLink value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityLink left, ActivityLink right) { throw null; }
+
+        public static bool operator !=(ActivityLink left, ActivityLink right) { throw null; }
+    }
+
+    public sealed partial class ActivityListener : IDisposable
+    {
+        public Action<Activity>? ActivityStarted { get { throw null; } set { } }
+
+        public Action<Activity>? ActivityStopped { get { throw null; } set { } }
+
+        public SampleActivity<ActivityContext>? Sample { get { throw null; } set { } }
+
+        public SampleActivity<string>? SampleUsingParentId { get { throw null; } set { } }
+
+        public Func<ActivitySource, bool>? ShouldListenTo { get { throw null; } set { } }
+
+        public void Dispose() { }
+    }
+
+    public enum ActivitySamplingResult
+    {
+        None = 0,
+        PropagationData = 1,
+        AllData = 2,
+        AllDataAndRecorded = 3
+    }
+
+    public sealed partial class ActivitySource : IDisposable
+    {
+        public ActivitySource(string name, string? version = "") { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public static void AddActivityListener(ActivityListener listener) { }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind) { throw null; }
+
+        public void Dispose() { }
+
+        public bool HasListeners() { throw null; }
+
+        public Activity? StartActivity(ActivityKind kind, ActivityContext parentContext = default, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default, string name = "") { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name = "", ActivityKind kind = ActivityKind.Internal) { throw null; }
+    }
+
+    public readonly partial struct ActivitySpanId : IEquatable<ActivitySpanId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivitySpanId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivitySpanId spanId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public static bool operator !=(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public enum ActivityStatusCode
+    {
+        Unset = 0,
+        Ok = 1,
+        Error = 2
+    }
+
+    public partial class ActivityTagsCollection : Collections.Generic.IDictionary<string, object?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable
+    {
+        public ActivityTagsCollection() { }
+
+        public ActivityTagsCollection(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> list) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public object? this[string key] { get { throw null; } set { } }
+
+        public Collections.Generic.ICollection<string> Keys { get { throw null; } }
+
+        public Collections.Generic.ICollection<object?> Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool ContainsKey(string key) { throw null; }
+
+        public void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public Enumerator GetEnumerator() { throw null; }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool Remove(string key) { throw null; }
+
+        Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object>> Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>>.GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetValue(string key, out object? value) { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            void Collections.IEnumerator.Reset() { }
+        }
+    }
+
+    [Flags]
+    public enum ActivityTraceFlags
+    {
+        None = 0,
+        Recorded = 1
+    }
+
+    public readonly partial struct ActivityTraceId : IEquatable<ActivityTraceId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivityTraceId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivityTraceId traceId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public static bool operator !=(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class DiagnosticListener : DiagnosticSource, IObservable<Collections.Generic.KeyValuePair<string, object?>>, IDisposable
+    {
+        public DiagnosticListener(string name) { }
+
+        public static IObservable<DiagnosticListener> AllListeners { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public virtual void Dispose() { }
+
+        public bool IsEnabled() { throw null; }
+
+        public override bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public override bool IsEnabled(string name) { throw null; }
+
+        public override void OnActivityExport(Activity activity, object? payload) { }
+
+        public override void OnActivityImport(Activity activity, object? payload) { }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled, Action<Activity, object?>? onActivityImport = null, Action<Activity, object?>? onActivityExport = null) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Predicate<string>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public override void Write(string name, object? value) { }
+    }
+
+    public abstract partial class DiagnosticSource
+    {
+        public virtual bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public abstract bool IsEnabled(string name);
+        public virtual void OnActivityExport(Activity activity, object? payload) { }
+
+        public virtual void OnActivityImport(Activity activity, object? payload) { }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public Activity StartActivity(Activity activity, object? args) { throw null; }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public void StopActivity(Activity activity, object? args) { }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public abstract void Write(string name, object? value);
+    }
+
+    public abstract partial class DistributedContextPropagator
+    {
+        public static DistributedContextPropagator Current { get { throw null; } set { } }
+
+        public abstract Collections.Generic.IReadOnlyCollection<string> Fields { get; }
+
+        public static DistributedContextPropagator CreateDefaultPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreateNoOutputPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreatePassThroughPropagator() { throw null; }
+
+        public abstract Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter);
+        public abstract void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState);
+        public abstract void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter);
+        public delegate void PropagatorGetterCallback(object? carrier, string fieldName, out string? fieldValue, out Collections.Generic.IEnumerable<string>? fieldValues);
+        public delegate void PropagatorSetterCallback(object? carrier, string fieldName, string fieldValue);
+    }
+
+    public delegate ActivitySamplingResult SampleActivity<T>(ref ActivityCreationOptions<T> options);
+    public partial struct TagList : Collections.Generic.IList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable, Collections.Generic.IReadOnlyList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IReadOnlyCollection<Collections.Generic.KeyValuePair<string, object?>>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public TagList(ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tagList) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Collections.Generic.KeyValuePair<string, object?> this[int index] { get { throw null; } set { } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public readonly bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public readonly void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public readonly void CopyTo(Span<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public readonly Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { throw null; }
+
+        public readonly int IndexOf(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void Insert(int index, Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        readonly Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+        }
+    }
+}
+
+namespace System.Diagnostics.Metrics
+{
+    public sealed partial class Counter<T> : Instrument<T> where T : struct
+    {
+        internal Counter() : base(default!, default!, default, default) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(T delta, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Add(T delta, in TagList tagList) { }
+
+        public void Add(T delta, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Add(T delta) { }
+    }
+
+    public sealed partial class Histogram<T> : Instrument<T> where T : struct
+    {
+        internal Histogram() : base(default!, default!, default, default) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Record(T value, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Record(T value, in TagList tagList) { }
+
+        public void Record(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Record(T value) { }
+    }
+
+    public abstract partial class Instrument
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) { }
+
+        public string? Description { get { throw null; } }
+
+        public bool Enabled { get { throw null; } }
+
+        public virtual bool IsObservable { get { throw null; } }
+
+        public Meter Meter { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string? Unit { get { throw null; } }
+
+        protected void Publish() { }
+    }
+
+    public abstract partial class Instrument<T> : Instrument where T : struct
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        protected void RecordMeasurement(T measurement, in TagList tagList) { }
+
+        protected void RecordMeasurement(T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        protected void RecordMeasurement(T measurement) { }
+    }
+
+    public delegate void MeasurementCallback<T>(Instrument instrument, T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags, object? state)
+        where T : struct;
+    public readonly partial struct Measurement<T>
+        where T : struct
+    {
+        private readonly T _Value_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Measurement(T value, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags) { }
+
+        public Measurement(T value, params Collections.Generic.KeyValuePair<string, object?>[]? tags) { }
+
+        public Measurement(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public Measurement(T value) { }
+
+        public ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public T Value { get { throw null; } }
+    }
+
+    public partial class Meter : IDisposable
+    {
+        public Meter(string name, string? version) { }
+
+        public Meter(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public Counter<T> CreateCounter<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public Histogram<T> CreateHistogram<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class MeterListener : IDisposable
+    {
+        public Action<Instrument, MeterListener>? InstrumentPublished { get { throw null; } set { } }
+
+        public Action<Instrument, object?>? MeasurementsCompleted { get { throw null; } set { } }
+
+        public object? DisableMeasurementEvents(Instrument instrument) { throw null; }
+
+        public void Dispose() { }
+
+        public void EnableMeasurementEvents(Instrument instrument, object? state = null) { }
+
+        public void RecordObservableInstruments() { }
+
+        public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementCallback)
+            where T : struct { }
+
+        public void Start() { }
+    }
+
+    public sealed partial class ObservableCounter<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableCounter() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public sealed partial class ObservableGauge<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableGauge() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public abstract partial class ObservableInstrument<T> : Instrument where T : struct
+    {
+        protected ObservableInstrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        public override bool IsObservable { get { throw null; } }
+
+        protected abstract Collections.Generic.IEnumerable<Measurement<T>> Observe();
+    }
+}

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/net6.0/System.Diagnostics.DiagnosticSource.cs
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/net6.0/System.Diagnostics.DiagnosticSource.cs
@@ -1,0 +1,720 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = "")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)\r\n\r\nCommonly Used Types:\r\nSystem.Diagnostics.DiagnosticListener\r\nSystem.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.3624.51421")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.36+f1dd57165bfd91875761329ac3a8b17f6606ad18")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Diagnostics
+{
+    public partial class Activity : IDisposable
+    {
+        public Activity(string operationName) { }
+
+        public ActivityTraceFlags ActivityTraceFlags { get { throw null; } set { } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Baggage { get { throw null; } }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public static Activity? Current { get { throw null; } set { } }
+
+        public static ActivityIdFormat DefaultIdFormat { get { throw null; } set { } }
+
+        public string DisplayName { get { throw null; } set { } }
+
+        public TimeSpan Duration { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityEvent> Events { get { throw null; } }
+
+        public static bool ForceDefaultIdFormat { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } }
+
+        public ActivityIdFormat IdFormat { get { throw null; } }
+
+        public bool IsAllDataRequested { get { throw null; } set { } }
+
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink> Links { get { throw null; } }
+
+        public string OperationName { get { throw null; } }
+
+        public Activity? Parent { get { throw null; } }
+
+        public string? ParentId { get { throw null; } }
+
+        public ActivitySpanId ParentSpanId { get { throw null; } }
+
+        public bool Recorded { get { throw null; } }
+
+        public string? RootId { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public DateTime StartTimeUtc { get { throw null; } }
+
+        public ActivityStatusCode Status { get { throw null; } }
+
+        public string? StatusDescription { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> TagObjects { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public static Func<ActivityTraceId>? TraceIdGenerator { get { throw null; } set { } }
+
+        public string? TraceStateString { get { throw null; } set { } }
+
+        public Activity AddBaggage(string key, string? value) { throw null; }
+
+        public Activity AddEvent(ActivityEvent e) { throw null; }
+
+        public Activity AddTag(string key, object? value) { throw null; }
+
+        public Activity AddTag(string key, string? value) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public string? GetBaggageItem(string key) { throw null; }
+
+        public object? GetCustomProperty(string propertyName) { throw null; }
+
+        public object? GetTagItem(string key) { throw null; }
+
+        public Activity SetBaggage(string key, string? value) { throw null; }
+
+        public void SetCustomProperty(string propertyName, object? propertyValue) { }
+
+        public Activity SetEndTime(DateTime endTimeUtc) { throw null; }
+
+        public Activity SetIdFormat(ActivityIdFormat format) { throw null; }
+
+        public Activity SetParentId(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None) { throw null; }
+
+        public Activity SetParentId(string parentId) { throw null; }
+
+        public Activity SetStartTime(DateTime startTimeUtc) { throw null; }
+
+        public Activity SetStatus(ActivityStatusCode code, string? description = null) { throw null; }
+
+        public Activity SetTag(string key, object? value) { throw null; }
+
+        public Activity Start() { throw null; }
+
+        public void Stop() { }
+    }
+
+    public readonly partial struct ActivityContext : IEquatable<ActivityContext>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags, string? traceState = null, bool isRemote = false) { }
+
+        public bool IsRemote { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public ActivityTraceFlags TraceFlags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public string? TraceState { get { throw null; } }
+
+        public readonly bool Equals(ActivityContext value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static bool operator !=(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static ActivityContext Parse(string traceParent, string? traceState) { throw null; }
+
+        public static bool TryParse(string? traceParent, string? traceState, out ActivityContext context) { throw null; }
+    }
+
+    public readonly partial struct ActivityCreationOptions<T>
+    {
+        private readonly T _Parent_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink>? Links { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public T Parent { get { throw null; } }
+
+        public ActivityTagsCollection SamplingTags { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+    }
+
+    public readonly partial struct ActivityEvent
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityEvent(string name, DateTimeOffset timestamp = default, ActivityTagsCollection? tags = null) { }
+
+        public ActivityEvent(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+    }
+
+    public enum ActivityIdFormat
+    {
+        Unknown = 0,
+        Hierarchical = 1,
+        W3C = 2
+    }
+
+    public enum ActivityKind
+    {
+        Internal = 0,
+        Server = 1,
+        Client = 2,
+        Producer = 3,
+        Consumer = 4
+    }
+
+    public readonly partial struct ActivityLink : IEquatable<ActivityLink>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityLink(ActivityContext context, ActivityTagsCollection? tags = null) { }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public readonly bool Equals(ActivityLink value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityLink left, ActivityLink right) { throw null; }
+
+        public static bool operator !=(ActivityLink left, ActivityLink right) { throw null; }
+    }
+
+    public sealed partial class ActivityListener : IDisposable
+    {
+        public Action<Activity>? ActivityStarted { get { throw null; } set { } }
+
+        public Action<Activity>? ActivityStopped { get { throw null; } set { } }
+
+        public SampleActivity<ActivityContext>? Sample { get { throw null; } set { } }
+
+        public SampleActivity<string>? SampleUsingParentId { get { throw null; } set { } }
+
+        public Func<ActivitySource, bool>? ShouldListenTo { get { throw null; } set { } }
+
+        public void Dispose() { }
+    }
+
+    public enum ActivitySamplingResult
+    {
+        None = 0,
+        PropagationData = 1,
+        AllData = 2,
+        AllDataAndRecorded = 3
+    }
+
+    public sealed partial class ActivitySource : IDisposable
+    {
+        public ActivitySource(string name, string? version = "") { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public static void AddActivityListener(ActivityListener listener) { }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind) { throw null; }
+
+        public void Dispose() { }
+
+        public bool HasListeners() { throw null; }
+
+        public Activity? StartActivity(ActivityKind kind, ActivityContext parentContext = default, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default, string name = "") { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name = "", ActivityKind kind = ActivityKind.Internal) { throw null; }
+    }
+
+    public readonly partial struct ActivitySpanId : IEquatable<ActivitySpanId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivitySpanId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivitySpanId spanId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public static bool operator !=(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public enum ActivityStatusCode
+    {
+        Unset = 0,
+        Ok = 1,
+        Error = 2
+    }
+
+    public partial class ActivityTagsCollection : Collections.Generic.IDictionary<string, object?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable
+    {
+        public ActivityTagsCollection() { }
+
+        public ActivityTagsCollection(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> list) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public object? this[string key] { get { throw null; } set { } }
+
+        public Collections.Generic.ICollection<string> Keys { get { throw null; } }
+
+        public Collections.Generic.ICollection<object?> Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool ContainsKey(string key) { throw null; }
+
+        public void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public Enumerator GetEnumerator() { throw null; }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool Remove(string key) { throw null; }
+
+        Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object>> Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>>.GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetValue(string key, out object? value) { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            void Collections.IEnumerator.Reset() { }
+        }
+    }
+
+    [Flags]
+    public enum ActivityTraceFlags
+    {
+        None = 0,
+        Recorded = 1
+    }
+
+    public readonly partial struct ActivityTraceId : IEquatable<ActivityTraceId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivityTraceId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivityTraceId traceId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public static bool operator !=(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class DiagnosticListener : DiagnosticSource, IObservable<Collections.Generic.KeyValuePair<string, object?>>, IDisposable
+    {
+        public DiagnosticListener(string name) { }
+
+        public static IObservable<DiagnosticListener> AllListeners { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public virtual void Dispose() { }
+
+        public bool IsEnabled() { throw null; }
+
+        public override bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public override bool IsEnabled(string name) { throw null; }
+
+        public override void OnActivityExport(Activity activity, object? payload) { }
+
+        public override void OnActivityImport(Activity activity, object? payload) { }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled, Action<Activity, object?>? onActivityImport = null, Action<Activity, object?>? onActivityExport = null) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Predicate<string>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public override void Write(string name, object? value) { }
+    }
+
+    public abstract partial class DiagnosticSource
+    {
+        public virtual bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public abstract bool IsEnabled(string name);
+        public virtual void OnActivityExport(Activity activity, object? payload) { }
+
+        public virtual void OnActivityImport(Activity activity, object? payload) { }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public Activity StartActivity(Activity activity, object? args) { throw null; }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public void StopActivity(Activity activity, object? args) { }
+
+        [CodeAnalysis.RequiresUnreferencedCode("The type of object being written to DiagnosticSource cannot be discovered statically.")]
+        public abstract void Write(string name, object? value);
+    }
+
+    public abstract partial class DistributedContextPropagator
+    {
+        public static DistributedContextPropagator Current { get { throw null; } set { } }
+
+        public abstract Collections.Generic.IReadOnlyCollection<string> Fields { get; }
+
+        public static DistributedContextPropagator CreateDefaultPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreateNoOutputPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreatePassThroughPropagator() { throw null; }
+
+        public abstract Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter);
+        public abstract void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState);
+        public abstract void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter);
+        public delegate void PropagatorGetterCallback(object? carrier, string fieldName, out string? fieldValue, out Collections.Generic.IEnumerable<string>? fieldValues);
+        public delegate void PropagatorSetterCallback(object? carrier, string fieldName, string fieldValue);
+    }
+
+    public delegate ActivitySamplingResult SampleActivity<T>(ref ActivityCreationOptions<T> options);
+    public partial struct TagList : Collections.Generic.IList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable, Collections.Generic.IReadOnlyList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IReadOnlyCollection<Collections.Generic.KeyValuePair<string, object?>>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public TagList(ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tagList) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Collections.Generic.KeyValuePair<string, object?> this[int index] { get { throw null; } set { } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public readonly bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public readonly void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public readonly void CopyTo(Span<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public readonly Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { throw null; }
+
+        public readonly int IndexOf(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void Insert(int index, Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        readonly Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+        }
+    }
+}
+
+namespace System.Diagnostics.Metrics
+{
+    public sealed partial class Counter<T> : Instrument<T> where T : struct
+    {
+        internal Counter() : base(default!, default!, default, default) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(T delta, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Add(T delta, in TagList tagList) { }
+
+        public void Add(T delta, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Add(T delta) { }
+    }
+
+    public sealed partial class Histogram<T> : Instrument<T> where T : struct
+    {
+        internal Histogram() : base(default!, default!, default, default) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Record(T value, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Record(T value, in TagList tagList) { }
+
+        public void Record(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Record(T value) { }
+    }
+
+    public abstract partial class Instrument
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) { }
+
+        public string? Description { get { throw null; } }
+
+        public bool Enabled { get { throw null; } }
+
+        public virtual bool IsObservable { get { throw null; } }
+
+        public Meter Meter { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string? Unit { get { throw null; } }
+
+        protected void Publish() { }
+    }
+
+    public abstract partial class Instrument<T> : Instrument where T : struct
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        protected void RecordMeasurement(T measurement, in TagList tagList) { }
+
+        protected void RecordMeasurement(T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        protected void RecordMeasurement(T measurement) { }
+    }
+
+    public delegate void MeasurementCallback<T>(Instrument instrument, T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags, object? state)
+        where T : struct;
+    public readonly partial struct Measurement<T>
+        where T : struct
+    {
+        private readonly T _Value_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Measurement(T value, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags) { }
+
+        public Measurement(T value, params Collections.Generic.KeyValuePair<string, object?>[]? tags) { }
+
+        public Measurement(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public Measurement(T value) { }
+
+        public ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public T Value { get { throw null; } }
+    }
+
+    public partial class Meter : IDisposable
+    {
+        public Meter(string name, string? version) { }
+
+        public Meter(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public Counter<T> CreateCounter<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public Histogram<T> CreateHistogram<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class MeterListener : IDisposable
+    {
+        public Action<Instrument, MeterListener>? InstrumentPublished { get { throw null; } set { } }
+
+        public Action<Instrument, object?>? MeasurementsCompleted { get { throw null; } set { } }
+
+        public object? DisableMeasurementEvents(Instrument instrument) { throw null; }
+
+        public void Dispose() { }
+
+        public void EnableMeasurementEvents(Instrument instrument, object? state = null) { }
+
+        public void RecordObservableInstruments() { }
+
+        public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementCallback)
+            where T : struct { }
+
+        public void Start() { }
+    }
+
+    public sealed partial class ObservableCounter<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableCounter() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public sealed partial class ObservableGauge<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableGauge() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public abstract partial class ObservableInstrument<T> : Instrument where T : struct
+    {
+        protected ObservableInstrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        public override bool IsObservable { get { throw null; } }
+
+        protected abstract Collections.Generic.IEnumerable<Measurement<T>> Observe();
+    }
+}

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/netstandard2.0/System.Diagnostics.DiagnosticSource.cs
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/lib/netstandard2.0/System.Diagnostics.DiagnosticSource.cs
@@ -1,0 +1,717 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)\r\n\r\nCommonly Used Types:\r\nSystem.Diagnostics.DiagnosticListener\r\nSystem.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.3624.51421")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.36+f1dd57165bfd91875761329ac3a8b17f6606ad18")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Diagnostics.DiagnosticSource")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Diagnostics
+{
+    public partial class Activity : IDisposable
+    {
+        public Activity(string operationName) { }
+
+        public ActivityTraceFlags ActivityTraceFlags { get { throw null; } set { } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Baggage { get { throw null; } }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public static Activity? Current { get { throw null; } set { } }
+
+        public static ActivityIdFormat DefaultIdFormat { get { throw null; } set { } }
+
+        public string DisplayName { get { throw null; } set { } }
+
+        public TimeSpan Duration { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityEvent> Events { get { throw null; } }
+
+        public static bool ForceDefaultIdFormat { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } }
+
+        public ActivityIdFormat IdFormat { get { throw null; } }
+
+        public bool IsAllDataRequested { get { throw null; } set { } }
+
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink> Links { get { throw null; } }
+
+        public string OperationName { get { throw null; } }
+
+        public Activity? Parent { get { throw null; } }
+
+        public string? ParentId { get { throw null; } }
+
+        public ActivitySpanId ParentSpanId { get { throw null; } }
+
+        public bool Recorded { get { throw null; } }
+
+        public string? RootId { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public DateTime StartTimeUtc { get { throw null; } }
+
+        public ActivityStatusCode Status { get { throw null; } }
+
+        public string? StatusDescription { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> TagObjects { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>> Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public static Func<ActivityTraceId>? TraceIdGenerator { get { throw null; } set { } }
+
+        public string? TraceStateString { get { throw null; } set { } }
+
+        public Activity AddBaggage(string key, string? value) { throw null; }
+
+        public Activity AddEvent(ActivityEvent e) { throw null; }
+
+        public Activity AddTag(string key, object? value) { throw null; }
+
+        public Activity AddTag(string key, string? value) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public string? GetBaggageItem(string key) { throw null; }
+
+        public object? GetCustomProperty(string propertyName) { throw null; }
+
+        public object? GetTagItem(string key) { throw null; }
+
+        public Activity SetBaggage(string key, string? value) { throw null; }
+
+        public void SetCustomProperty(string propertyName, object? propertyValue) { }
+
+        public Activity SetEndTime(DateTime endTimeUtc) { throw null; }
+
+        public Activity SetIdFormat(ActivityIdFormat format) { throw null; }
+
+        public Activity SetParentId(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None) { throw null; }
+
+        public Activity SetParentId(string parentId) { throw null; }
+
+        public Activity SetStartTime(DateTime startTimeUtc) { throw null; }
+
+        public Activity SetStatus(ActivityStatusCode code, string? description = null) { throw null; }
+
+        public Activity SetTag(string key, object? value) { throw null; }
+
+        public Activity Start() { throw null; }
+
+        public void Stop() { }
+    }
+
+    public readonly partial struct ActivityContext : IEquatable<ActivityContext>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags, string? traceState = null, bool isRemote = false) { }
+
+        public bool IsRemote { get { throw null; } }
+
+        public ActivitySpanId SpanId { get { throw null; } }
+
+        public ActivityTraceFlags TraceFlags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+
+        public string? TraceState { get { throw null; } }
+
+        public readonly bool Equals(ActivityContext value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static bool operator !=(ActivityContext left, ActivityContext right) { throw null; }
+
+        public static ActivityContext Parse(string traceParent, string? traceState) { throw null; }
+
+        public static bool TryParse(string? traceParent, string? traceState, out ActivityContext context) { throw null; }
+    }
+
+    public readonly partial struct ActivityCreationOptions<T>
+    {
+        private readonly T _Parent_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityKind Kind { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<ActivityLink>? Links { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public T Parent { get { throw null; } }
+
+        public ActivityTagsCollection SamplingTags { get { throw null; } }
+
+        public ActivitySource Source { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public ActivityTraceId TraceId { get { throw null; } }
+    }
+
+    public readonly partial struct ActivityEvent
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityEvent(string name, DateTimeOffset timestamp = default, ActivityTagsCollection? tags = null) { }
+
+        public ActivityEvent(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+    }
+
+    public enum ActivityIdFormat
+    {
+        Unknown = 0,
+        Hierarchical = 1,
+        W3C = 2
+    }
+
+    public enum ActivityKind
+    {
+        Internal = 0,
+        Server = 1,
+        Client = 2,
+        Producer = 3,
+        Consumer = 4
+    }
+
+    public readonly partial struct ActivityLink : IEquatable<ActivityLink>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ActivityLink(ActivityContext context, ActivityTagsCollection? tags = null) { }
+
+        public ActivityContext Context { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? Tags { get { throw null; } }
+
+        public readonly bool Equals(ActivityLink value) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityLink left, ActivityLink right) { throw null; }
+
+        public static bool operator !=(ActivityLink left, ActivityLink right) { throw null; }
+    }
+
+    public sealed partial class ActivityListener : IDisposable
+    {
+        public Action<Activity>? ActivityStarted { get { throw null; } set { } }
+
+        public Action<Activity>? ActivityStopped { get { throw null; } set { } }
+
+        public SampleActivity<ActivityContext>? Sample { get { throw null; } set { } }
+
+        public SampleActivity<string>? SampleUsingParentId { get { throw null; } set { } }
+
+        public Func<ActivitySource, bool>? ShouldListenTo { get { throw null; } set { } }
+
+        public void Dispose() { }
+    }
+
+    public enum ActivitySamplingResult
+    {
+        None = 0,
+        PropagationData = 1,
+        AllData = 2,
+        AllDataAndRecorded = 3
+    }
+
+    public sealed partial class ActivitySource : IDisposable
+    {
+        public ActivitySource(string name, string? version = "") { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public static void AddActivityListener(ActivityListener listener) { }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, ActivityIdFormat idFormat = ActivityIdFormat.Unknown) { throw null; }
+
+        public Activity? CreateActivity(string name, ActivityKind kind) { throw null; }
+
+        public void Dispose() { }
+
+        public bool HasListeners() { throw null; }
+
+        public Activity? StartActivity(ActivityKind kind, ActivityContext parentContext = default, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default, string name = "") { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name, ActivityKind kind, string parentId, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags = null, Collections.Generic.IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default) { throw null; }
+
+        public Activity? StartActivity(string name = "", ActivityKind kind = ActivityKind.Internal) { throw null; }
+    }
+
+    public readonly partial struct ActivitySpanId : IEquatable<ActivitySpanId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivitySpanId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivitySpanId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivitySpanId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivitySpanId spanId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public static bool operator !=(ActivitySpanId spanId1, ActivitySpanId spandId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public enum ActivityStatusCode
+    {
+        Unset = 0,
+        Ok = 1,
+        Error = 2
+    }
+
+    public partial class ActivityTagsCollection : Collections.Generic.IDictionary<string, object?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable
+    {
+        public ActivityTagsCollection() { }
+
+        public ActivityTagsCollection(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>> list) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public object? this[string key] { get { throw null; } set { } }
+
+        public Collections.Generic.ICollection<string> Keys { get { throw null; } }
+
+        public Collections.Generic.ICollection<object?> Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool ContainsKey(string key) { throw null; }
+
+        public void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public Enumerator GetEnumerator() { throw null; }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public bool Remove(string key) { throw null; }
+
+        Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object>> Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>>.GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetValue(string key, out object? value) { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            void Collections.IEnumerator.Reset() { }
+        }
+    }
+
+    [Flags]
+    public enum ActivityTraceFlags
+    {
+        None = 0,
+        Recorded = 1
+    }
+
+    public readonly partial struct ActivityTraceId : IEquatable<ActivityTraceId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly void CopyTo(Span<byte> destination) { }
+
+        public static ActivityTraceId CreateFromBytes(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromString(ReadOnlySpan<char> idData) { throw null; }
+
+        public static ActivityTraceId CreateFromUtf8String(ReadOnlySpan<byte> idData) { throw null; }
+
+        public static ActivityTraceId CreateRandom() { throw null; }
+
+        public readonly bool Equals(ActivityTraceId traceId) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public static bool operator !=(ActivityTraceId traceId1, ActivityTraceId traceId2) { throw null; }
+
+        public readonly string ToHexString() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class DiagnosticListener : DiagnosticSource, IObservable<Collections.Generic.KeyValuePair<string, object?>>, IDisposable
+    {
+        public DiagnosticListener(string name) { }
+
+        public static IObservable<DiagnosticListener> AllListeners { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public virtual void Dispose() { }
+
+        public bool IsEnabled() { throw null; }
+
+        public override bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public override bool IsEnabled(string name) { throw null; }
+
+        public override void OnActivityExport(Activity activity, object? payload) { }
+
+        public override void OnActivityImport(Activity activity, object? payload) { }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled, Action<Activity, object?>? onActivityImport = null, Action<Activity, object?>? onActivityExport = null) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer, Predicate<string>? isEnabled) { throw null; }
+
+        public virtual IDisposable Subscribe(IObserver<Collections.Generic.KeyValuePair<string, object?>> observer) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public override void Write(string name, object? value) { }
+    }
+
+    public abstract partial class DiagnosticSource
+    {
+        public virtual bool IsEnabled(string name, object? arg1, object? arg2 = null) { throw null; }
+
+        public abstract bool IsEnabled(string name);
+        public virtual void OnActivityExport(Activity activity, object? payload) { }
+
+        public virtual void OnActivityImport(Activity activity, object? payload) { }
+
+        public Activity StartActivity(Activity activity, object? args) { throw null; }
+
+        public void StopActivity(Activity activity, object? args) { }
+
+        public abstract void Write(string name, object? value);
+    }
+
+    public abstract partial class DistributedContextPropagator
+    {
+        public static DistributedContextPropagator Current { get { throw null; } set { } }
+
+        public abstract Collections.Generic.IReadOnlyCollection<string> Fields { get; }
+
+        public static DistributedContextPropagator CreateDefaultPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreateNoOutputPropagator() { throw null; }
+
+        public static DistributedContextPropagator CreatePassThroughPropagator() { throw null; }
+
+        public abstract Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, string?>>? ExtractBaggage(object? carrier, PropagatorGetterCallback? getter);
+        public abstract void ExtractTraceIdAndState(object? carrier, PropagatorGetterCallback? getter, out string? traceId, out string? traceState);
+        public abstract void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter);
+        public delegate void PropagatorGetterCallback(object? carrier, string fieldName, out string? fieldValue, out Collections.Generic.IEnumerable<string>? fieldValues);
+        public delegate void PropagatorSetterCallback(object? carrier, string fieldName, string fieldValue);
+    }
+
+    public delegate ActivitySamplingResult SampleActivity<T>(ref ActivityCreationOptions<T> options);
+    public partial struct TagList : Collections.Generic.IList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerable, Collections.Generic.IReadOnlyList<Collections.Generic.KeyValuePair<string, object?>>, Collections.Generic.IReadOnlyCollection<Collections.Generic.KeyValuePair<string, object?>>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public TagList(ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tagList) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Collections.Generic.KeyValuePair<string, object?> this[int index] { get { throw null; } set { } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(string key, object? value) { }
+
+        public void Clear() { }
+
+        public readonly bool Contains(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public readonly void CopyTo(Collections.Generic.KeyValuePair<string, object?>[] array, int arrayIndex) { }
+
+        public readonly void CopyTo(Span<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public readonly Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>> GetEnumerator() { throw null; }
+
+        public readonly int IndexOf(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void Insert(int index, Collections.Generic.KeyValuePair<string, object?> item) { }
+
+        public bool Remove(Collections.Generic.KeyValuePair<string, object?> item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        readonly Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, object?>>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public Collections.Generic.KeyValuePair<string, object?> Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+        }
+    }
+}
+
+namespace System.Diagnostics.Metrics
+{
+    public sealed partial class Counter<T> : Instrument<T> where T : struct
+    {
+        internal Counter() : base(default!, default!, default, default) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Add(T delta, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Add(T delta, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Add(T delta, in TagList tagList) { }
+
+        public void Add(T delta, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Add(T delta) { }
+    }
+
+    public sealed partial class Histogram<T> : Instrument<T> where T : struct
+    {
+        internal Histogram() : base(default!, default!, default, default) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        public void Record(T value, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        public void Record(T value, params Collections.Generic.KeyValuePair<string, object?>[] tags) { }
+
+        public void Record(T value, in TagList tagList) { }
+
+        public void Record(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public void Record(T value) { }
+    }
+
+    public abstract partial class Instrument
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) { }
+
+        public string? Description { get { throw null; } }
+
+        public bool Enabled { get { throw null; } }
+
+        public virtual bool IsObservable { get { throw null; } }
+
+        public Meter Meter { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string? Unit { get { throw null; } }
+
+        protected void Publish() { }
+    }
+
+    public abstract partial class Instrument<T> : Instrument where T : struct
+    {
+        protected Instrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2, Collections.Generic.KeyValuePair<string, object?> tag3) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag1, Collections.Generic.KeyValuePair<string, object?> tag2) { }
+
+        protected void RecordMeasurement(T measurement, Collections.Generic.KeyValuePair<string, object?> tag) { }
+
+        protected void RecordMeasurement(T measurement, in TagList tagList) { }
+
+        protected void RecordMeasurement(T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        protected void RecordMeasurement(T measurement) { }
+    }
+
+    public delegate void MeasurementCallback<T>(Instrument instrument, T measurement, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags, object? state)
+        where T : struct;
+    public readonly partial struct Measurement<T>
+        where T : struct
+    {
+        private readonly T _Value_k__BackingField;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Measurement(T value, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object?>>? tags) { }
+
+        public Measurement(T value, params Collections.Generic.KeyValuePair<string, object?>[]? tags) { }
+
+        public Measurement(T value, ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> tags) { }
+
+        public Measurement(T value) { }
+
+        public ReadOnlySpan<Collections.Generic.KeyValuePair<string, object?>> Tags { get { throw null; } }
+
+        public T Value { get { throw null; } }
+    }
+
+    public partial class Meter : IDisposable
+    {
+        public Meter(string name, string? version) { }
+
+        public Meter(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public string? Version { get { throw null; } }
+
+        public Counter<T> CreateCounter<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public Histogram<T> CreateHistogram<T>(string name, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableCounter<T> CreateObservableCounter<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<T> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Collections.Generic.IEnumerable<Measurement<T>>> observeValues, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public ObservableGauge<T> CreateObservableGauge<T>(string name, Func<Measurement<T>> observeValue, string? unit = null, string? description = null)
+            where T : struct { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class MeterListener : IDisposable
+    {
+        public Action<Instrument, MeterListener>? InstrumentPublished { get { throw null; } set { } }
+
+        public Action<Instrument, object?>? MeasurementsCompleted { get { throw null; } set { } }
+
+        public object? DisableMeasurementEvents(Instrument instrument) { throw null; }
+
+        public void Dispose() { }
+
+        public void EnableMeasurementEvents(Instrument instrument, object? state = null) { }
+
+        public void RecordObservableInstruments() { }
+
+        public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementCallback)
+            where T : struct { }
+
+        public void Start() { }
+    }
+
+    public sealed partial class ObservableCounter<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableCounter() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public sealed partial class ObservableGauge<T> : ObservableInstrument<T> where T : struct
+    {
+        internal ObservableGauge() : base(default!, default!, default, default) { }
+
+        protected override Collections.Generic.IEnumerable<Measurement<T>> Observe() { throw null; }
+    }
+
+    public abstract partial class ObservableInstrument<T> : Instrument where T : struct
+    {
+        protected ObservableInstrument(Meter meter, string name, string? unit, string? description) : base(default!, default!, default, default) { }
+
+        public override bool IsObservable { get { throw null; } }
+
+        protected abstract Collections.Generic.IEnumerable<Measurement<T>> Observe();
+    }
+}

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/system.diagnostics.diagnosticsource.nuspec
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/6.0.2/system.diagnostics.diagnosticsource.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Diagnostics.DiagnosticSource</id>
+    <version>6.0.2</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)
+
+Commonly Used Types:
+System.Diagnostics.DiagnosticListener
+System.Diagnostics.DiagnosticSource</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="f1dd57165bfd91875761329ac3a8b17f6606ad18" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net6.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Adds the following new reference packages required by the 9.0 product source build:

- `Microsoft.Bcl.TimeProvider` 8.0.1
- `Microsoft.Extensions.Logging.Abstractions` 2.1.0
- `Microsoft.Extensions.Logging.Abstractions` 6.0.0
- `System.Diagnostics.DiagnosticSource` 6.0.2