### PR TITLE
Tolerate missing 'origin' remote when packing OpenTelemetry packages

### DIFF
--- a/src/externalPackages/patches/opentelemetry-dotnet-contrib/0002-Source-build-tolerate-missing-origin-remote-during-p.patch
+++ b/src/externalPackages/patches/opentelemetry-dotnet-contrib/0002-Source-build-tolerate-missing-origin-remote-during-p.patch
@@ -1,0 +1,35 @@
+From e2f1a26d7cb8cf1fd165db2b454333c3b511a636 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Tue, 30 Jun 2026 10:28:22 -0500
+Subject: [PATCH] Source-build: tolerate missing 'origin' remote during pack
+
+The IncludeReadmeAndReleaseNotesInPackages target runs
+'git remote get-url origin' through an MSBuild Exec task to compute the
+repository URL. When the local checkout has no remote named 'origin',
+git writes "error: No such remote 'origin'" to stderr. MSBuild promotes
+any output line matching the canonical error format to a real build
+error, which fails 'dotnet pack' (exit 1) even though IgnoreExitCode is
+already set.
+
+Add IgnoreStandardErrorWarningFormat="True" to the Exec so the stderr
+line is not interpreted as a build error. Packing then succeeds when no
+'origin' remote exists, and the URL computation is unaffected when one
+does.
+
+See https://github.com/dotnet/source-build/issues/5599
+---
+ build/Common.prod.props | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/Common.prod.props b/build/Common.prod.props
+index 0ca89189..46e2c8f4 100644
+--- a/build/Common.prod.props
++++ b/build/Common.prod.props
+@@ -103,6 +103,7 @@
+       Command="git remote get-url origin"
+       ConsoleToMsBuild="True"
+       IgnoreExitCode="True"
++      IgnoreStandardErrorWarningFormat="True"
+       StandardOutputImportance="low">
+       <Output PropertyName="GitOriginConsoleOutput" TaskParameter="ConsoleOutput"/>
+       <Output PropertyName="GitOriginExitCode" TaskParameter="ExitCode"/>

--- a/src/externalPackages/patches/opentelemetry-dotnet/0002-Source-build-tolerate-missing-origin-remote-during-p.patch
+++ b/src/externalPackages/patches/opentelemetry-dotnet/0002-Source-build-tolerate-missing-origin-remote-during-p.patch
@@ -1,0 +1,35 @@
+From 2c324453939922623123778045fc46f863de2c20 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Tue, 30 Jun 2026 10:23:31 -0500
+Subject: [PATCH] Source-build: tolerate missing 'origin' remote during pack
+
+The IncludeReadmeAndReleaseNotesInPackages target runs
+'git remote get-url origin' through an MSBuild Exec task to compute the
+repository URL. When the local checkout has no remote named 'origin',
+git writes "error: No such remote 'origin'" to stderr. MSBuild promotes
+any output line matching the canonical error format to a real build
+error, which fails 'dotnet pack' (exit 1) even though IgnoreExitCode is
+already set.
+
+Add IgnoreStandardErrorWarningFormat="True" to the Exec so the stderr
+line is not interpreted as a build error. Packing then succeeds when no
+'origin' remote exists, and the URL computation is unaffected when one
+does.
+
+See https://github.com/dotnet/source-build/issues/5599
+---
+ build/Common.prod.props | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/build/Common.prod.props b/build/Common.prod.props
+index b844ce97..c4c0a2d1 100644
+--- a/build/Common.prod.props
++++ b/build/Common.prod.props
+@@ -118,6 +118,7 @@
+       Command="git remote get-url origin"
+       ConsoleToMsBuild="True"
+       IgnoreExitCode="True"
++      IgnoreStandardErrorWarningFormat="True"
+       StandardOutputImportance="low">
+       <Output PropertyName="GitOriginConsoleOutput" TaskParameter="ConsoleOutput"/>
+       <Output PropertyName="GitOriginExitCode" TaskParameter="ExitCode"/>


### PR DESCRIPTION
Add patches for `opentelemetry-dotnet` and `opentelemetry-dotnet-contrib` that set `IgnoreStandardErrorWarningFormat="True"` on the `git remote get-url origin` exec in the `IncludeReadmeAndReleaseNotesInPackages` target. Without an `origin` remote, git writes `error: No such remote 'origin'` to stderr, which MSBuild promotes to a build error and fails `dotnet pack` even though `IgnoreExitCode` is set.

Fixes https://github.com/dotnet/source-build/issues/5599