### PR TITLE
Add OpenTelemetry.PersistentStorage.FileSystem to source-build-assets

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,6 +29,8 @@
     <OpenTelemetryDotNetReleaseVersion>1.15.3</OpenTelemetryDotNetReleaseVersion>
     <OpenTelemetryDotNetContribHttpReleaseVersion>1.15.1</OpenTelemetryDotNetContribHttpReleaseVersion>
     <OpenTelemetryDotNetContribRuntimeReleaseVersion>1.15.1</OpenTelemetryDotNetContribRuntimeReleaseVersion>
+    <OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion>1.0.3</OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion>
+    <OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion>1.0.3</OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/externalPackages/projects/opentelemetry-dotnet-contrib.proj
+++ b/src/externalPackages/projects/opentelemetry-dotnet-contrib.proj
@@ -22,6 +22,8 @@
     <PropertyGroup>
       <HttpProject>$(ProjectDirectory)src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj</HttpProject>
       <RuntimeProject>$(ProjectDirectory)src/OpenTelemetry.Instrumentation.Runtime/OpenTelemetry.Instrumentation.Runtime.csproj</RuntimeProject>
+      <PersistentStorageAbstractionsProject>$(ProjectDirectory)src/OpenTelemetry.PersistentStorage.Abstractions/OpenTelemetry.PersistentStorage.Abstractions.csproj</PersistentStorageAbstractionsProject>
+      <PersistentStorageFileSystemProject>$(ProjectDirectory)src/OpenTelemetry.PersistentStorage.FileSystem/OpenTelemetry.PersistentStorage.FileSystem.csproj</PersistentStorageFileSystemProject>
 
       <CommonBuildArgs>/p:Configuration=$(Configuration)</CommonBuildArgs>
       <CommonBuildArgs>$(CommonBuildArgs) /p:DelaySign=$(DelaySign)</CommonBuildArgs>
@@ -49,6 +51,8 @@
            the MSFT-shipped package by ExternalPackageTests / UpdateExternalMetadata. -->
       <HttpVersionArgs>/p:Version=$(OpenTelemetryDotNetContribHttpReleaseVersion) /p:AssemblyVersion=$(OpenTelemetryDotNetContribHttpAssemblyVersionOverride) /p:FileVersion=$(OpenTelemetryDotNetContribHttpReleaseVersion).$(OpenTelemetryDotNetContribHttpFileVersionRevision)</HttpVersionArgs>
       <RuntimeVersionArgs>/p:Version=$(OpenTelemetryDotNetContribRuntimeReleaseVersion) /p:AssemblyVersion=$(OpenTelemetryDotNetContribRuntimeAssemblyVersionOverride) /p:FileVersion=$(OpenTelemetryDotNetContribRuntimeReleaseVersion).$(OpenTelemetryDotNetContribRuntimeFileVersionRevision)</RuntimeVersionArgs>
+      <PersistentStorageAbstractionsVersionArgs>/p:Version=$(OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion) /p:AssemblyVersion=$(OpenTelemetryDotNetContribPersistentStorageAbstractionsAssemblyVersionOverride) /p:FileVersion=$(OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion).$(OpenTelemetryDotNetContribPersistentStorageAbstractionsFileVersionRevision)</PersistentStorageAbstractionsVersionArgs>
+      <PersistentStorageFileSystemVersionArgs>/p:Version=$(OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion) /p:AssemblyVersion=$(OpenTelemetryDotNetContribPersistentStorageFileSystemAssemblyVersionOverride) /p:FileVersion=$(OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion).$(OpenTelemetryDotNetContribPersistentStorageFileSystemFileVersionRevision)</PersistentStorageFileSystemVersionArgs>
     </PropertyGroup>
 
     <!-- OpenTelemetry.Instrumentation.Http -->
@@ -67,6 +71,26 @@
           WorkingDirectory="$(ProjectDirectory)"
           IgnoreStandardErrorWarningFormat="true" />
     <Exec Command="&quot;$(DotNetTool)&quot; pack /bl:$(ArtifactsLogRepoDir)pack_Runtime.binlog $(RuntimeProject) $(PackArgs) $(RuntimeVersionArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <!-- OpenTelemetry.PersistentStorage.Abstractions (packed before FileSystem, which references it) -->
+    <Exec Command="&quot;$(DotNetTool)&quot; restore /bl:$(ArtifactsLogRepoDir)restore_PersistentStorageAbstractions.binlog $(PersistentStorageAbstractionsProject) $(CommonBuildArgs) $(PersistentStorageAbstractionsVersionArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="&quot;$(DotNetTool)&quot; pack /bl:$(ArtifactsLogRepoDir)pack_PersistentStorageAbstractions.binlog $(PersistentStorageAbstractionsProject) $(PackArgs) $(PersistentStorageAbstractionsVersionArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <!-- OpenTelemetry.PersistentStorage.FileSystem (depends on PersistentStorage.Abstractions) -->
+    <Exec Command="&quot;$(DotNetTool)&quot; restore /bl:$(ArtifactsLogRepoDir)restore_PersistentStorageFileSystem.binlog $(PersistentStorageFileSystemProject) $(CommonBuildArgs) $(PersistentStorageFileSystemVersionArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="&quot;$(DotNetTool)&quot; pack /bl:$(ArtifactsLogRepoDir)pack_PersistentStorageFileSystem.binlog $(PersistentStorageFileSystemProject) $(PackArgs) $(PersistentStorageFileSystemVersionArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/src/externalPackages/projects/opentelemetry-dotnet-contrib.props
+++ b/src/externalPackages/projects/opentelemetry-dotnet-contrib.props
@@ -28,6 +28,18 @@
     <OpenTelemetryDotNetContribRuntimeFileVersionRevision>1029</OpenTelemetryDotNetContribRuntimeFileVersionRevision>
     <!-- AssemblyVersion of MSFT-shipped OpenTelemetry.Instrumentation.Runtime 1.15.1. -->
     <OpenTelemetryDotNetContribRuntimeAssemblyVersionOverride>1.15.1.1029</OpenTelemetryDotNetContribRuntimeAssemblyVersionOverride>
+    <!-- OpenTelemetry.PersistentStorage.Abstractions and OpenTelemetry.PersistentStorage.FileSystem are
+         released together from a single PersistentStorage-<version> tag, so they share a ReleaseVersion and
+         BuildNumber. The pinned submodule commit's PersistentStorage sources are identical to the
+         PersistentStorage-1.0.3 release (only CHANGELOG.md differs), so both build as 1.0.3. -->
+    <!-- BuildNumber from MSFT-shipped OpenTelemetry.PersistentStorage.Abstractions release (tag PersistentStorage-1.0.3). -->
+    <OpenTelemetryDotNetContribPersistentStorageAbstractionsFileVersionRevision>1043</OpenTelemetryDotNetContribPersistentStorageAbstractionsFileVersionRevision>
+    <!-- AssemblyVersion of MSFT-shipped OpenTelemetry.PersistentStorage.Abstractions 1.0.3. -->
+    <OpenTelemetryDotNetContribPersistentStorageAbstractionsAssemblyVersionOverride>1.0.3.1043</OpenTelemetryDotNetContribPersistentStorageAbstractionsAssemblyVersionOverride>
+    <!-- BuildNumber from MSFT-shipped OpenTelemetry.PersistentStorage.FileSystem release (tag PersistentStorage-1.0.3). -->
+    <OpenTelemetryDotNetContribPersistentStorageFileSystemFileVersionRevision>1043</OpenTelemetryDotNetContribPersistentStorageFileSystemFileVersionRevision>
+    <!-- AssemblyVersion of MSFT-shipped OpenTelemetry.PersistentStorage.FileSystem 1.0.3. -->
+    <OpenTelemetryDotNetContribPersistentStorageFileSystemAssemblyVersionOverride>1.0.3.1043</OpenTelemetryDotNetContribPersistentStorageFileSystemAssemblyVersionOverride>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,6 +54,16 @@
       <FileVersionRevisionProperty>OpenTelemetryDotNetContribRuntimeFileVersionRevision</FileVersionRevisionProperty>
       <AssemblyVersionOverrideProperty>OpenTelemetryDotNetContribRuntimeAssemblyVersionOverride</AssemblyVersionOverrideProperty>
       <ReleaseVersionProperty>OpenTelemetryDotNetContribRuntimeReleaseVersion</ReleaseVersionProperty>
+    </FileVersionValidationPackage>
+    <FileVersionValidationPackage Include="OpenTelemetry.PersistentStorage.Abstractions">
+      <FileVersionRevisionProperty>OpenTelemetryDotNetContribPersistentStorageAbstractionsFileVersionRevision</FileVersionRevisionProperty>
+      <AssemblyVersionOverrideProperty>OpenTelemetryDotNetContribPersistentStorageAbstractionsAssemblyVersionOverride</AssemblyVersionOverrideProperty>
+      <ReleaseVersionProperty>OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion</ReleaseVersionProperty>
+    </FileVersionValidationPackage>
+    <FileVersionValidationPackage Include="OpenTelemetry.PersistentStorage.FileSystem">
+      <FileVersionRevisionProperty>OpenTelemetryDotNetContribPersistentStorageFileSystemFileVersionRevision</FileVersionRevisionProperty>
+      <AssemblyVersionOverrideProperty>OpenTelemetryDotNetContribPersistentStorageFileSystemAssemblyVersionOverride</AssemblyVersionOverrideProperty>
+      <ReleaseVersionProperty>OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion</ReleaseVersionProperty>
     </FileVersionValidationPackage>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds `OpenTelemetry.PersistentStorage.FileSystem` (and its required dependency `OpenTelemetry.PersistentStorage.Abstractions`) from the `opentelemetry-dotnet-contrib` repo to source-build-assets, in preparation for an upcoming change in dotnet/sdk. This follows the exact pattern already used for the existing `OpenTelemetry.Instrumentation.Http` and `OpenTelemetry.Instrumentation.Runtime` packages built from the same submodule.

## Changes

- **`eng/Versions.props`** — added `OpenTelemetryDotNetContribPersistentStorageAbstractionsReleaseVersion` and `OpenTelemetryDotNetContribPersistentStorageFileSystemReleaseVersion` (both `1.0.3`).
- **`src/externalPackages/projects/opentelemetry-dotnet-contrib.props`** — added AssemblyVersion / FileVersion-revision override properties (both `1.0.3.1043`, revision `1043`) and two `FileVersionValidationPackage` items so the metadata-update tool and `ExternalPackageTests` validate them against the Microsoft-shipped packages.
- **`src/externalPackages/projects/opentelemetry-dotnet-contrib.proj`** — added restore + pack steps for Abstractions (packed first, since FileSystem references it) and FileSystem.

The submodule pointer is unchanged.

## Why version 1.0.3

The pinned submodule commit (`b89c765`, the `Instrumentation.Runtime-1.15.1` tag) contains PersistentStorage sources that are **identical to the `PersistentStorage-1.0.3` release** — the diff between them touches only `CHANGELOG.md`. The later `1.1.0` tag has real code changes, so `1.0.3` is the correct version for this commit.

## Validation

- Confirmed the Microsoft-shipped `1.0.3` packages ship with `AssemblyVersion = FileVersion = 1.0.3.1043` for both assemblies.
- Packed both projects locally with the source-build build args and verified:
  - Output packages `OpenTelemetry.PersistentStorage.Abstractions.1.0.3.nupkg` and `OpenTelemetry.PersistentStorage.FileSystem.1.0.3.nupkg`
  - Assemblies at `1.0.3.1043` across `net462` and `netstandard2.0`
  - `FileSystem` correctly depends on `OpenTelemetry.PersistentStorage.Abstractions 1.0.3`

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>